### PR TITLE
Add Picture-in-Picture demo

### DIFF
--- a/public/demos/picture-in-picture.html
+++ b/public/demos/picture-in-picture.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Feature Policy: Picture-in-Picture example</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
+  <link rel="stylesheet" href="/styles/main.css">
+  <link rel="stylesheet" href="/styles/header.css">
+</head>
+<body class="body-padding">
+
+<details class="details">
+  <!-- filled dynamically -->
+</details>
+
+<h2 id="feature-allowed-banner">
+  <span id="allowfeature">...</span>
+</h2>
+
+<p>The video below uses native controls. Reload the page with the feature policy on/off to see the effect on its controls.</p>
+
+<div class="layout center">
+  <video src="https://clips.vorwaerts-gmbh.de/big_buck_bunny.webm" controls></video>
+</div>
+
+<script type="module">
+import {initPage} from '/js/shared.js';
+initPage();
+</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120357238-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-120357238-1');
+</script>
+</body>
+</html>

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -76,12 +76,12 @@
   "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
   "usage": {
     "on": "picture-in-picture 'self'",
-    "off": "picture-in-picture https://google-developers.appspot.com"
+    "off": "picture-in-picture 'none'"
   },
   "examples": {
     "header": [
       "FeaturePolicy: picture-in-picture 'self'",
-      "FeaturePolicy: picture-in-picture https://google-developers.appspot.com"
+      "FeaturePolicy: picture-in-picture 'none'"
     ]
   }
 }]

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -67,4 +67,21 @@
       "&lt;iframe src=\"https://google-developers.appspot.com/demo/...\"\n        allow=\"geolocation https://google-developers.appspot.com\"><\/iframe>"
     ]
   }
+}, {
+  "id": "picture-in-picture",
+  "name": "Picture-in-Picture",
+  "url": "/demos/picture-in-picture.html",
+  "chromeStatusLink": "https://www.chromestatus.com/features/5729206566649856",
+  "what": "Controls access to Picture in Picture.",
+  "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
+  "usage": {
+    "on": "picture-in-picture 'self'",
+    "off": "picture-in-picture https://google-developers.appspot.com"
+  },
+  "examples": {
+    "header": [
+      "FeaturePolicy: picture-in-picture 'self'",
+      "FeaturePolicy: picture-in-picture https://google-developers.appspot.com"
+    ]
+  }
 }]


### PR DESCRIPTION
Picture-in-Picture Feature Policy is already implemented in Chrome Canary but still requires some flags: https://github.com/WICG/picture-in-picture/blob/master/implementation-status.md

This CL makes sure we have a demo featuring Picture-in-Picture FP.