### PR TITLE
Update sync-xhr wording on banner

### DIFF
--- a/public/demos/sync-xhr.html
+++ b/public/demos/sync-xhr.html
@@ -32,7 +32,7 @@
 </h2>
 
 <p>Reload the page. When the page allows synchronous XHRs, you will eventually see a list of web
-features supported in Chrome. Note that the green banner doesn't render until the JSON request has
+features supported in Chrome. Note that the banner doesn't render until the JSON request has
 finished. This is because the main thread is blocked by the request + parsing of JSON data. When the
 page turns on this policy, the browser simply blocks the sync XHR request.</p>
 


### PR DESCRIPTION
The banner ain't green any more, in fact it last changed from red to blue in bb4625daa8729b72a353d922357a74a81ec67a55.