### PR TITLE
Let autoplay page use local demo video

### DIFF
--- a/public/demos/autoplay.html
+++ b/public/demos/autoplay.html
@@ -24,6 +24,7 @@
 <div class="layout center">
   <video src="/video/mixkit-rain-falling-from-the-roof-on-a-rainy-day-2716.mp4" autoplay controls></video>
 </div>
+<p style="color: gray;">Source: https://mixkit.co/free-stock-video/rain-falling-from-the-roof-on-a-rainy-day-2716/</p>
 
 <script type="module">
 import {initPage} from '/js/shared.js';

--- a/public/demos/autoplay.html
+++ b/public/demos/autoplay.html
@@ -22,7 +22,7 @@
 <p>The video below uses <code>autoplay</code> attribute. Reload the page with the feature policy on/off to see the effect on it auto playing.</p>
 
 <div class="layout center">
-  <video src="https://clips.vorwaerts-gmbh.de/big_buck_bunny.webm" autoplay controls></video>
+  <video src="/video/mixkit-rain-falling-from-the-roof-on-a-rainy-day-2716.mp4" autoplay controls></video>
 </div>
 
 <script type="module">


### PR DESCRIPTION
Previous [demo video](https://clips.vorwaerts-gmbh.de/big_buck_bunny.webm) used for auto-play policy was broken. The external website no longer host the video. 

This patch replace the external link to a local demo video.