### PR TITLE
Document Policy demos

### DIFF
--- a/public/demos/oversized-images.html
+++ b/public/demos/oversized-images.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: oversized-images example</title>
+  <title>Document Policy: oversized-images example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/oversized-images.html
+++ b/public/demos/oversized-images.html
@@ -20,8 +20,8 @@
 </h2>
 
 <p>Click the buttons above to see how the page loads with different policy values.
-  Images that have image_size / container_size ratio exceed given threshold should
-  render as placeholder images.</p>
+ Images where the ratio of intrinsic dimensions to container size exceeds the given
+ threshold should render as placeholder images.</p>
 
 <!--
 For optimized images:

--- a/public/demos/oversized-images.html
+++ b/public/demos/oversized-images.html
@@ -19,9 +19,9 @@
   <span id="allowfeature">...</span>
 </h2>
 
-<p>Click the disallow/allow buttons above to see how the page loads with the policy on and off.
-  When the policy is on, you will see images that have intrinsic dimentions which are much larger
-  than their container size render as placeholder images.</p>
+<p>Click the buttons above to see how the page loads with different policy values.
+  Images that have image_size / container_size ratio exceed given threshold should
+  render as placeholder images.</p>
 
 <!--
 For optimized images:

--- a/public/demos/sync-script.html
+++ b/public/demos/sync-script.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: sync-script example</title>
+  <title>Document Policy: sync-script example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/unoptimized-lossy-images.html
+++ b/public/demos/unoptimized-lossy-images.html
@@ -19,8 +19,8 @@
   <span id="allowfeature">...</span>
 </h2>
 
-<p>Click the disallow/allow buttons above to see how the page loads with the policy on and off.
- When the policy is on, you will see images whose file size is over the threshold render as placeholder images.
+<p>Click the buttons above to see how the page loads with different policy values.
+ Images with bpp(byte per pixel) exceeds the threshold should render as placeholder images.
 </p>
 
 <!--

--- a/public/demos/unoptimized-lossy-images.html
+++ b/public/demos/unoptimized-lossy-images.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: unoptimized-{lossy,lossless}-images example</title>
+  <title>Document Policy: unoptimized-{lossy,lossless}-images example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/unoptimized-lossy-images.html
+++ b/public/demos/unoptimized-lossy-images.html
@@ -20,7 +20,7 @@
 </h2>
 
 <p>Click the buttons above to see how the page loads with different policy values.
- Images with bpp(byte per pixel) exceeds the threshold should render as placeholder images.
+ Images where the compression ratio (bytes per pixel) exceeds the threshold should render as placeholder images.
 </p>
 
 <!--

--- a/public/demos/unsized-media.html
+++ b/public/demos/unsized-media.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: unsized-media example</title>
+  <title>Document Policy: unsized-media example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -133,8 +133,10 @@ const buildImplementedPolicies = () => {
   const categories = Array.from(categoryMapping.entries());
   const markup = repeat(categories, (item) => item[0], ([cat, policies], i) => {
     const items = repeat(policies, (p) => p.id, (p, i) => {
+      const firstUsage = p.usage[0];
+      const [, headerParam] = firstUsage;
       return html`
-        <a href="${p.url}?on" class="policy-name" onclick="updatePage(this, '${p.id}')">
+        <a href="${p.url}?${headerParam}" class="policy-name" onclick="updatePage(this, '${p.id}')">
           ${p.name}
           <img src="/img/flag-24px.svg" class="flag-icon ${p.supported ? 'supported' : ''}"
                title="Requires a flag">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -49,7 +49,8 @@ async function loadPage() {
     }
 
     const contentFrame = document.querySelector('iframe.content-view');
-    const pagePath = location.href;
+    // Prefix url.pathname with /demos to get the iframe url.
+    const pagePath = '/demos' + url.pathname;
     contentFrame.src = pagePath;
     document.body.classList.toggle('on', policyOn);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -38,7 +38,6 @@ async function loadPage() {
 
   if (url.pathname !== '/') {
     const demoPage = url.pathname.slice(1).split('.')[0];
-    const policyOn = url.searchParams.has('on');
 
     policy = await getPolicy(demoPage);
 
@@ -49,15 +48,26 @@ async function loadPage() {
     }
 
     const contentFrame = document.querySelector('iframe.content-view');
-    // Prefix url.pathname with /demos to get the iframe url.
-    const pagePath = '/demos' + url.pathname;
+    const pagePath = policy.url + url.search;
     contentFrame.src = pagePath;
-    document.body.classList.toggle('on', policyOn);
 
     gtag('config', 'UA-120357238-1', {page_path: pagePath});
   }
 
   return policy;
+}
+
+/**
+ * Updates the iframe content when policy value selector is clicked.
+ *
+ * @param {!HTMLAnchorElement} anchor
+ */
+function updatePolicyValue(anchor) {
+  anchor.parentElement.querySelectorAll('a').forEach(a => a.removeAttribute('active'));
+  anchor.setAttribute('active', '');
+  const href = anchor.getAttribute('href').replace('/demos', '');
+  window.history.pushState(null, null, href);
+  loadPage();
 }
 
 /**
@@ -173,4 +183,5 @@ document.addEventListener('click', e => {
 })();
 
 window.updatePage = updatePage;
+window.updatePolicyValue = updatePolicyValue;
 window.toggleDrawer = toggleDrawer;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -146,10 +146,9 @@ const buildImplementedPolicies = () => {
   const categories = Array.from(categoryMapping.entries());
   const markup = repeat(categories, (item) => item[0], ([cat, policies], i) => {
     const items = repeat(policies, (p) => p.id, (p, i) => {
-      const firstUsage = p.usage[0];
-      const [, headerParam] = firstUsage;
+      const firstUsage = Object.keys(p.usage).sort()[0];
       return html`
-        <a href="${p.url}?${headerParam}" class="policy-name" onclick="updatePage(this, '${p.id}')">
+        <a href="${p.url}?${firstUsage}" class="policy-name" onclick="updatePage(this, '${p.id}')">
           ${p.name}
           <img src="/img/flag-24px.svg" class="flag-icon ${p.supported ? 'supported' : ''}"
                title="Requires a flag">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -49,8 +49,7 @@ async function loadPage() {
     }
 
     const contentFrame = document.querySelector('iframe.content-view');
-    contentFrame.allow = policyOn ? policy.usage.on : policy.usage.off;
-    const pagePath = policyOn ? `${policy.url}?on` : policy.url;
+    const pagePath = location.href;
     contentFrame.src = pagePath;
     document.body.classList.toggle('on', policyOn);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -76,10 +76,12 @@ function updatePolicyValue(anchor) {
  * @param {string} id Feature policy id.
  */
 async function updatePage(anchor, id) {
-  updateDetailsHeader(await getPolicy(id));
+  // Update window URL first, so that |updateDetailsHeader| can observe
+  // the latest URL.
   const href = anchor.getAttribute('href').replace('/demos', '');
   window.history.pushState(null, null, href);
 
+  updateDetailsHeader(await getPolicy(id));
   loadPage();
 }
 

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -6,13 +6,13 @@
   "what": "Allows developers to enforce that image/video elements have explicit dimensions. If dimensions aren't specified on the element, the browser sets a default size of 300x150 when this policy is active.",
   "why": "Reduces the layout work the browser has to perform.",
   "usage": {
-    "off": "Feature-Policy: unsized-media 'self'",
-    "on": "Feature-Policy: unsized-media 'none'"
+    "off": "Document-Policy: unsized-media",
+    "on": "Document-Policy: unsized-media=?0"
   },
   "examples": {
     "header": [
-      "Feature-Policy: unsized-media 'none'",
-      "Feature-Policy: unsized-media https://img.cdn.com"
+      "Document-Policy: unsized-media",
+      "Document-Policy: unsized-media=?0"
     ]
   }
 }, {

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -5,9 +5,10 @@
   "url": "/demos/unsized-media.html",
   "what": "Allows developers to enforce that image/video elements have explicit dimensions. If dimensions aren't specified on the element, the browser sets a default size of 300x150 when this policy is active.",
   "why": "Reduces the layout work the browser has to perform.",
+  "policyType": "Document-Policy",
   "usage": {
-    "off": "Document-Policy: unsized-media",
-    "on": "Document-Policy: unsized-media=?0"
+    "off": "unsized-media",
+    "on": "unsized-media=?0"
   },
   "examples": {
     "header": [
@@ -23,9 +24,10 @@
   "chromeStatusLink": "https://www.chromestatus.com/feature/5154875084111872",
   "what": "Disallows the use of synchronous XMLHttpRequests.",
   "why": "Using synchronous XHRs can cause jank on the main thread and be detrimental to user experience. Although the HTML spec has <a href=\"https://xhr.spec.whatwg.org/#sync-warning\" target=\"_blank\">deprecated sync XHRs</a>, developers are still able to use it for XHR requests where <code>responseType=\"text\"</code>.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: sync-xhr 'self'",
-    "on": "Feature-Policy: sync-xhr 'none'"
+    "off": "sync-xhr 'self'",
+    "on": "sync-xhr 'none'"
   },
   "examples": {
     "header": [
@@ -40,9 +42,10 @@
   "chromeStatusLink": "https://www.chromestatus.com/feature/5100524789563392",
   "what": "Allows cross-origin videos and movies to autoplay.",
   "why": "By default, Chrome allows the `autoplay` attribute on videos within same-origin iframes. To enable cross-origin videos to autoplay (or disallow same-origin videos from auto playing), sites can use this feature policy.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: autoplay 'self'",
-    "on": "Feature-Policy: autoplay 'none'"
+    "off": "autoplay 'self'",
+    "on": "autoplay 'none'"
   },
   "examples": {
     "header": [
@@ -58,9 +61,10 @@
   "chromeStatusLink": null,
   "what": "Allows/disables the use of the Geolocation API.",
   "why": "By default, Chrome blocks the usage of geolocation in cross-origin iframes. Developers can control this behavior (or geolocation access in general) using this feature policy.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: geolocation 'self'",
-    "on": "Feature-Policy: geolocation https://google-developers.appspot.com"
+    "off": "geolocation 'self'",
+    "on": "geolocation https://google-developers.appspot.com"
   },
   "examples": {
     "header": [
@@ -79,9 +83,10 @@
   "chromeStatusLink": "https://www.chromestatus.com/features/5729206566649856",
   "what": "Controls access to Picture in Picture.",
   "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "on": "Feature-Policy: picture-in-picture 'self'",
-    "off": "Feature-Policy: picture-in-picture 'none'"
+    "on": "picture-in-picture 'self'",
+    "off": "picture-in-picture 'none'"
   },
   "examples": {
     "header": [
@@ -96,9 +101,10 @@
   "url": "/demos/animations.html",
   "what": "Restricts the set of CSS properties which can be animated to opacity, transform, and filter.",
   "why": "Ensures smooth animations, by only allowing those properties which can be animated on the GPU using the hardware acceleration.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: animations 'self'",
-    "on": "Feature-Policy: animations 'none'"
+    "off": "animations 'self'",
+    "on": "animations 'none'"
   },
   "examples": {
     "header": [
@@ -115,11 +121,12 @@
   "url": "/demos/oversized-images.html",
   "what": "Ensures instrinsic size of images are not more than X times larger than their container size.",
   "why": "Image bloat is a large problem on the web. Sending unnecessarily large images is bad for performance, UX, and wastes bandwidth.",
+  "policyType": "Document-Policy",
   "usage_desc": "Maximum image_size / container_size ratio",
   "usage": {
-    "1.0": "Document-Policy: oversized-images=1.0",
-    "2.0": "Document-Policy: oversized-images=2.0",
-    "4.0": "Document-Policy: oversized-images=4.0"
+    "1.0": "oversized-images=1.0",
+    "2.0": "oversized-images=2.0",
+    "4.0": "oversized-images=4.0"
   },
   "examples": {
     "header": [
@@ -133,11 +140,12 @@
   "url": "/demos/unoptimized-lossy-images.html",
   "what": "Requires the data size of images (in bytes) to be no more than X times bigger than its rendering area (in pixels). Images violating this policy render as placeholder images.",
   "why": "Ensures optimized performance with images by minimizing file size, reducing image bloat and saving bandwidth.",
+  "policyType": "Document-Policy",
   "usage_desc": "Maximum byte per pixel",
   "usage": {
-    "1.0": "Document-Policy: unoptimized-lossy-images=1.0, unoptimized-lossless-images=1.0, unoptimized-lossless-images-strict=1.0",
-    "2.0": "Document-Policy: unoptimized-lossy-images=2.0, unoptimized-lossless-images=2.0, unoptimized-lossless-images-strict=2.0",
-    "4.0": "Document-Policy: unoptimized-lossy-images=4.0, unoptimized-lossless-images=4.0, unoptimized-lossless-images-strict=4.0"
+    "1.0": "unoptimized-lossy-images=1.0, unoptimized-lossless-images=1.0, unoptimized-lossless-images-strict=1.0",
+    "2.0": "unoptimized-lossy-images=2.0, unoptimized-lossless-images=2.0, unoptimized-lossless-images-strict=2.0",
+    "4.0": "unoptimized-lossy-images=4.0, unoptimized-lossless-images=4.0, unoptimized-lossless-images-strict=4.0"
   },
   "examples": {
     "header": [
@@ -153,9 +161,10 @@
   "url": "/demos/sync-script.html",
   "what": "Prevents synchronous, parsing blocking scripts from executing.",
   "why": "Inline scripts and <code>&lt;script src></code> without the <code>defer</code>/<code>async</code> attributes block the parser. This can lead to bad performance and poor UX. Instead, use <code>defer</code>/<code>async</code> when loading scripts, dynamically inject them into the page using JS, or use ES Modules (which are defer loaded by default). These solutions will not violate this feature policy.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: sync-script 'self'",
-    "on": "Feature-Policy: sync-script 'none'"
+    "off": "sync-script 'self'",
+    "on": "sync-script 'none'"
   },
   "examples": {
     "header": [
@@ -172,9 +181,10 @@
   "url": "/demos/vertical-scroll.html",
   "what": "Controls whether embedded content can interfere with vertical scrolling.",
   "why": "By default, iframe content can use <code>touch-action: none</code>, <code>e.preventDefault()</code> in touch events, and the DOM Scroll APIs to prevent and/or alter how content scrolls vertically. This policy ensures vertical scrolling is not blocked by preventing these features from working.",
+  "policyType": "Feature-Policy",
   "usage": {
-    "off": "Feature-Policy: vertical-scroll 'self'",
-    "on": "Feature-Policy: vertical-scroll 'none'"
+    "off": "vertical-scroll 'self'",
+    "on": "vertical-scroll 'none'"
   },
   "examples": {
     "header": [

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -160,18 +160,15 @@
   "type": "performance",
   "url": "/demos/sync-script.html",
   "what": "Prevents synchronous, parsing blocking scripts from executing.",
-  "why": "Inline scripts and <code>&lt;script src></code> without the <code>defer</code>/<code>async</code> attributes block the parser. This can lead to bad performance and poor UX. Instead, use <code>defer</code>/<code>async</code> when loading scripts, dynamically inject them into the page using JS, or use ES Modules (which are defer loaded by default). These solutions will not violate this feature policy.",
-  "policyType": "Feature-Policy",
+  "why": "Inline scripts and <code>&lt;script src></code> without the <code>defer</code>/<code>async</code> attributes block the parser. This can lead to bad performance and poor UX. Instead, use <code>defer</code>/<code>async</code> when loading scripts, dynamically inject them into the page using JS, or use ES Modules (which are defer loaded by default). These solutions will not violate this document policy.",
+  "policyType": "Document-Policy",
   "usage": {
-    "off": "sync-script 'self'",
-    "on": "sync-script 'none'"
+    "off": "sync-script",
+    "on": "sync-script=?0"
   },
   "examples": {
     "header": [
-      "Feature-Policy: sync-script 'none'"
-    ],
-    "iframe": [
-      "&lt;iframe allow=\"sync-script 'none'\" src=\"...\"><\/iframe>"
+      "Document-Policy: sync-script=?0"
     ]
   }
 }, {

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -6,8 +6,8 @@
   "what": "Allows developers to enforce that image/video elements have explicit dimensions. If dimensions aren't specified on the element, the browser sets a default size of 300x150 when this policy is active.",
   "why": "Reduces the layout work the browser has to perform.",
   "usage": {
-    "off": "unsized-media 'self'",
-    "on": "unsized-media 'none'"
+    "off": "Feature-Policy: unsized-media 'self'",
+    "on": "Feature-Policy: unsized-media 'none'"
   },
   "examples": {
     "header": [
@@ -24,8 +24,8 @@
   "what": "Disallows the use of synchronous XMLHttpRequests.",
   "why": "Using synchronous XHRs can cause jank on the main thread and be detrimental to user experience. Although the HTML spec has <a href=\"https://xhr.spec.whatwg.org/#sync-warning\" target=\"_blank\">deprecated sync XHRs</a>, developers are still able to use it for XHR requests where <code>responseType=\"text\"</code>.",
   "usage": {
-    "off": "sync-xhr 'self'",
-    "on": "sync-xhr 'none'"
+    "off": "Feature-Policy: sync-xhr 'self'",
+    "on": "Feature-Policy: sync-xhr 'none'"
   },
   "examples": {
     "header": [
@@ -41,8 +41,8 @@
   "what": "Allows cross-origin videos and movies to autoplay.",
   "why": "By default, Chrome allows the `autoplay` attribute on videos within same-origin iframes. To enable cross-origin videos to autoplay (or disallow same-origin videos from auto playing), sites can use this feature policy.",
   "usage": {
-    "off": "autoplay 'self'",
-    "on": "autoplay 'none'"
+    "off": "Feature-Policy: autoplay 'self'",
+    "on": "Feature-Policy: autoplay 'none'"
   },
   "examples": {
     "header": [
@@ -59,8 +59,8 @@
   "what": "Allows/disables the use of the Geolocation API.",
   "why": "By default, Chrome blocks the usage of geolocation in cross-origin iframes. Developers can control this behavior (or geolocation access in general) using this feature policy.",
   "usage": {
-    "off": "geolocation 'self'",
-    "on": "geolocation https://google-developers.appspot.com"
+    "off": "Feature-Policy: geolocation 'self'",
+    "on": "Feature-Policy: geolocation https://google-developers.appspot.com"
   },
   "examples": {
     "header": [
@@ -80,8 +80,8 @@
   "what": "Controls access to Picture in Picture.",
   "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
   "usage": {
-    "on": "picture-in-picture 'self'",
-    "off": "picture-in-picture 'none'"
+    "on": "Feature-Policy: picture-in-picture 'self'",
+    "off": "Feature-Policy: picture-in-picture 'none'"
   },
   "examples": {
     "header": [
@@ -97,8 +97,8 @@
   "what": "Restricts the set of CSS properties which can be animated to opacity, transform, and filter.",
   "why": "Ensures smooth animations, by only allowing those properties which can be animated on the GPU using the hardware acceleration.",
   "usage": {
-    "off": "animations 'self'",
-    "on": "animations 'none'"
+    "off": "Feature-Policy: animations 'self'",
+    "on": "Feature-Policy: animations 'none'"
   },
   "examples": {
     "header": [
@@ -115,13 +115,15 @@
   "url": "/demos/oversized-images.html",
   "what": "Ensures instrinsic size of images are not more than X times larger than their container size.",
   "why": "Image bloat is a large problem on the web. Sending unnecessarily large images is bad for performance, UX, and wastes bandwidth.",
+  "usage_desc": "Maximum image_size / container_size ratio",
   "usage": {
-    "off": "oversized-images 'self'(inf)",
-    "on": "oversized-images 'self'(2.0)"
+    "1.0": "Document-Policy: oversized-images=1.0",
+    "2.0": "Document-Policy: oversized-images=2.0",
+    "4.0": "Document-Policy: oversized-images=4.0"
   },
   "examples": {
     "header": [
-      "Feature-Policy: oversized-images 'self'(2.0) *(inf)"
+      "Document-Policy: oversized-images=2.0"
     ]
   }
 }, {
@@ -131,13 +133,17 @@
   "url": "/demos/unoptimized-lossy-images.html",
   "what": "Requires the data size of images (in bytes) to be no more than X times bigger than its rendering area (in pixels). Images violating this policy render as placeholder images.",
   "why": "Ensures optimized performance with images by minimizing file size, reducing image bloat and saving bandwidth.",
+  "usage_desc": "Maximum byte per pixel",
   "usage": {
-    "off": "unoptimized-lossy-images 'self'(inf); unoptimized-lossless-images 'self'(inf); unoptimized-lossless-images-strict 'self'(inf);",
-    "on": "unoptimized-lossy-images 'self'(0.5); unoptimized-lossless-images 'self'(1); unoptimized-lossless-images-strict 'self'(1);"
+    "1.0": "Document-Policy: unoptimized-lossy-images=1.0, unoptimized-lossless-images=1.0, unoptimized-lossless-images-strict=1.0",
+    "2.0": "Document-Policy: unoptimized-lossy-images=2.0, unoptimized-lossless-images=2.0, unoptimized-lossless-images-strict=2.0",
+    "4.0": "Document-Policy: unoptimized-lossy-images=4.0, unoptimized-lossless-images=4.0, unoptimized-lossless-images-strict=4.0"
   },
   "examples": {
     "header": [
-      "Feature-Policy: unoptimized-lossy-images 'self'(0.5) *(inf); unoptimized-lossless-images 'self'(1) *(inf); unoptimized-lossless-images-strict 'self'(1) *(inf);"
+      "Document-Policy: unoptimized-lossy-images=1.0",
+      "Document-Policy: unoptimized-lossless-images=1.0",
+      "Document-Policy: unoptimized-lossless-images-strict=1.0"
     ]
   }
 }, {
@@ -148,8 +154,8 @@
   "what": "Prevents synchronous, parsing blocking scripts from executing.",
   "why": "Inline scripts and <code>&lt;script src></code> without the <code>defer</code>/<code>async</code> attributes block the parser. This can lead to bad performance and poor UX. Instead, use <code>defer</code>/<code>async</code> when loading scripts, dynamically inject them into the page using JS, or use ES Modules (which are defer loaded by default). These solutions will not violate this feature policy.",
   "usage": {
-    "off": "sync-script 'self'",
-    "on": "sync-script 'none'"
+    "off": "Feature-Policy: sync-script 'self'",
+    "on": "Feature-Policy: sync-script 'none'"
   },
   "examples": {
     "header": [
@@ -167,8 +173,8 @@
   "what": "Controls whether embedded content can interfere with vertical scrolling.",
   "why": "By default, iframe content can use <code>touch-action: none</code>, <code>e.preventDefault()</code> in touch events, and the DOM Scroll APIs to prevent and/or alter how content scrolls vertically. This policy ensures vertical scrolling is not blocked by preventing these features from working.",
   "usage": {
-    "off": "vertical-scroll 'self'",
-    "on": "vertical-scroll 'none'"
+    "off": "Feature-Policy: vertical-scroll 'self'",
+    "on": "Feature-Policy: vertical-scroll 'none'"
   },
   "examples": {
     "header": [

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -98,8 +98,7 @@ function showDetails() {
  */
 function policyValueSelector(policy) {
   const desc = policy.usage_desc ? `<span>${policy.usage_desc}:</span>` : '';
-  const optionButtons = Object.entries(policy.usage).map(entry => {
-    const [policyValue, header] = entry;
+  const optionButtons = Object.entries(policy.usage).map(([policyValue, header]) => {
     const [policyType, policyString] = header.split(':');
     const href = `${policy.url}?${policyType}=${encodeURIComponent(policyString)}`;
 

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -103,10 +103,19 @@ function policyValueSelector(policy) {
       .sort(([ka, va], [kb, vb]) => ka < kb)
       .map(([policyValue, _]) => {
         const currentPolicyValue = new URL(location).search.slice(1);
-        const active = policyValue.localeCompare(currentPolicyValue) === 0 ? 'active' : '';
-        return html `
-        <a href="${policy.url}?${policyValue}"
-           class="try-button ${active} onclick="updatePolicyValue(this)">${policyValue}</a>`;
+        // Note: inline 'active' attribute as a template argument
+        // will result in lithtml not correctly render the element.
+        if (policyValue.localeCompare(currentPolicyValue) === 0) {
+          return html `
+          <a href="${policy.url}?${policyValue}"
+            class="try-button" onclick=updatePolicyValue(this) active
+          >${policyValue}</a>`;
+        } else {
+          return html `
+          <a href="${policy.url}?${policyValue}"
+            class="try-button" onclick=updatePolicyValue(this)
+          >${policyValue}</a>`;
+        }
       });
 
   return html `

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -98,20 +98,21 @@ function showDetails() {
  * @return {string}
  */
 function policyValueSelector(policy) {
-  const desc = policy.usage_desc ? `<span>${policy.usage_desc}:</span>` : '';
+  const desc = policy.usage_desc ? html `<span>${policy.usage_desc}:</span>` : '';
   const optionButtons = Object.entries(policy.usage)
       .sort(([ka, va], [kb, vb]) => ka < kb)
       .map(([policyValue, _]) => {
         const currentPolicyValue = new URL(location).search.slice(1);
         const active = policyValue.localeCompare(currentPolicyValue) === 0 ? 'active' : '';
-        return `<a href="${policy.url}?${policyValue}" class="try-button" ${active}
-            onclick="updatePolicyValue(this)">${policyValue}</a>`;
+        return html `
+        <a href="${policy.url}?${policyValue}"
+           class="try-button ${active} onclick="updatePolicyValue(this)">${policyValue}</a>`;
       });
 
-  return `
+  return html `
     <span class="trylinks">
       ${desc}
-      ${optionButtons.join('\n')}
+      ${optionButtons}
     </span>
   `;
 }
@@ -131,7 +132,7 @@ function updateDetailsHeader(policy) {
   const tmpl = html`
     <summary>
       <span class="policyname">${policy.name}</span>
-      ${unsafeHTML(policyValueSelector(policy))}
+      ${policyValueSelector(policy)}
       <span class="menu-button" onclick="toggleDrawer()"><img src="/img/menu24px.svg"></span>
     </summary>
     <ul class="details-info">

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -90,6 +90,32 @@ function showDetails() {
 }
 
 /**
+ * Render the policy value selection bar html string based on policy object
+ * given.
+ *
+ * @param {Object} policy
+ * @return {string}
+ */
+function policyValueSelector(policy) {
+  const desc = policy.usage_desc ? `<span>${policy.usage_desc}:</span>` : '';
+  const optionButtons = Object.entries(policy.usage).map(entry => {
+    const [policyValue, header] = entry;
+    const [policyType, policyString] = header.split(':');
+    const href = `${policy.url}?${policyType}=${encodeURIComponent(policyString)}`;
+
+    return `<a href="${href}" class="enable-button try-button"
+          onclick="updatePage(this, '${policy.id}')">${policyValue}</a>`;
+  });
+
+  return `
+    <span class="trylinks">
+      ${desc}
+      ${optionButtons.join('\n')}
+    </span>
+  `;
+}
+
+/**
  * Updates the UI metadata header when a feature policy is selected.
  * @param {!Object} policy
  */
@@ -103,13 +129,8 @@ function updateDetailsHeader(policy) {
 
   const tmpl = html`
     <summary>
-      <span><span class="policyname">${policy.name}</span> feature policy</span>
-      <span class="trylinks">
-        <a href="${policy.url}?on" class="enable-button try-button"
-           onclick="updatePage(this, '${policy.id}')">On</a>
-        <a href="${policy.url}" class="disable-button try-button"
-           onclick="updatePage(this, '${policy.id}')">Off</a>
-      </span>
+      <span class="policyname">${policy.name}</span>
+      ${unsafeHTML(policyValueSelector(policy))}
       <span class="menu-button" onclick="toggleDrawer()"><img src="/img/menu24px.svg"></span>
     </summary>
     <ul class="details-info">

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -16,6 +16,7 @@
 
 import {html, render} from '/lit-html/lit-html.js';
 import {unsafeHTML} from '/lit-html/directives/unsafe-html.js';
+import {ifDefined} from '/lit-html/directives/if-defined.js';
 
 export const policyOn = new URL(location).searchParams.has('on');
 export const currentPolicyId = new URL(location).pathname.split('/').slice(-1)[0].split('.')[0];
@@ -103,19 +104,11 @@ function policyValueSelector(policy) {
       .sort(([ka, va], [kb, vb]) => ka < kb)
       .map(([policyValue, _]) => {
         const currentPolicyValue = new URL(location).search.slice(1);
-        // Note: inline 'active' attribute as a template argument
-        // will result in lithtml not correctly render the element.
-        if (policyValue.localeCompare(currentPolicyValue) === 0) {
-          return html `
-          <a href="${policy.url}?${policyValue}"
-            class="try-button" onclick=updatePolicyValue(this) active
-          >${policyValue}</a>`;
-        } else {
-          return html `
-          <a href="${policy.url}?${policyValue}"
-            class="try-button" onclick=updatePolicyValue(this)
-          >${policyValue}</a>`;
-        }
+        const active = policyValue.localeCompare(currentPolicyValue) === 0 ? 'active' : undefined;
+        return html `
+        <a href="${policy.url}?${policyValue}"
+          class="try-button" onclick=updatePolicyValue(this) active="${ifDefined(active)}"
+        >${policyValue}</a>`;
       });
 
   return html `

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -28,19 +28,12 @@ details.details {
 .details .trylinks .try-button:hover {
   border-bottom: 4px solid var(--enable-color) !important;
 }
-body.on .details .trylinks .enable-button {
+.details .trylinks a[active] {
   border-bottom: 4px solid var(--enable-color);
   font-weight: 600;
 }
-body.on .details .trylinks .disable-button {
+.details .trylinks a:not([active]) {
   border-bottom: 4px solid var(--disable-color);
-}
-body:not(.on) .details .trylinks .enable-button {
-  border-bottom: 4px solid var(--disable-color);
-}
-body:not(.on) .details .trylinks .disable-button {
-  border-bottom: 4px solid var(--enable-color);
-  font-weight: 600;
 }
 .details summary {
   position: relative;

--- a/server.mjs
+++ b/server.mjs
@@ -61,7 +61,7 @@ const RECOGNIZED_HEADERS = [
   'Document-Policy',
   'Require-Document-Policy',
 ];
-app.use(function echoHeader(req, res, next) {
+app.use('/demos', function echoHeader(req, res, next) {
   const query = req.query;
   for (const policyName of RECOGNIZED_HEADERS) {
     if (policyName in query) {

--- a/server.mjs
+++ b/server.mjs
@@ -65,7 +65,8 @@ app.use(function echoHeader(req, res, next) {
   const query = req.query;
   for (const policyName of RECOGNIZED_HEADERS) {
     if (policyName in query) {
-      res.append(policyName, query[policyName]);
+      console.log(policyName + ': ' + decodeURIComponent(query[policyName]));
+      res.append(policyName, decodeURIComponent(query[policyName]));
     }
   }
   next();

--- a/server.mjs
+++ b/server.mjs
@@ -65,7 +65,6 @@ app.use(function echoHeader(req, res, next) {
   const query = req.query;
   for (const policyName of RECOGNIZED_HEADERS) {
     if (policyName in query) {
-      console.log(policyName + ': ' + decodeURIComponent(query[policyName]));
       res.append(policyName, decodeURIComponent(query[policyName]));
     }
   }

--- a/server.mjs
+++ b/server.mjs
@@ -18,6 +18,7 @@
 
 import fs from 'fs';
 import express from 'express';
+import bodyParser from 'body-parser';
 
 const OT_TOKEN_UNOPT_IMAGES = 'AiGYzl8A17mcET9ObZ6QbC5vmOlCWk+4jZwZptDwKw8Iguu3jX2e6WVzUbHZpW0zPgqZdq/WSSUysH2chjMtCA4AAAByeyJvcmlnaW4iOiJodHRwczovL2ZlYXR1cmUtcG9saWN5LWRlbW9zLmFwcHNwb3QuY29tOjQ0MyIsImZlYXR1cmUiOiJVbm9wdGltaXplZEltYWdlUG9saWNpZXMiLCJleHBpcnkiOjE1NjQ2Nzg1NjF9';
 const OT_TOKEN_UNOPT_IMAGES_LOCALHOST = 'AuqelXxw7r91rz8mkV5fJnMkjNXY6vtmpd8lzATN2KGpwd0D6akFg7GBtigifHHuqk7zAnOvo2NlUnmAQTmSTQkAAABbeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiVW5vcHRpbWl6ZWRJbWFnZVBvbGljaWVzIiwiZXhwaXJ5IjoxNTY0Njc4MzU1fQ==';
@@ -33,6 +34,9 @@ function errorHandler(err, req, res, next) {
 /* eslint-enable */
 
 const app = express();
+app.use(bodyParser.urlencoded({
+  extended: false,
+}));
 
 app.use(function forceSSL(req, res, next) {
   const fromCron = req.get('X-Appengine-Cron');
@@ -47,6 +51,23 @@ app.use(function commonHeaders(req, res, next) {
   // TODO: Re-enable when OT working correctly
   // res.set('Origin-Trial', OT_TOKEN_UNOPT_IMAGES);
   // res.set('Origin-Trial', OT_TOKEN_UNOPT_IMAGES_LOCALHOST);
+  next();
+});
+
+// Echo the get parameter string as response header.
+const RECOGNIZED_HEADERS = [
+  'Feature-Policy',
+  'Permissions-Policy',
+  'Document-Policy',
+  'Require-Document-Policy',
+];
+app.use(function echoHeader(req, res, next) {
+  const query = req.query;
+  for (const policyName of RECOGNIZED_HEADERS) {
+    if (policyName in query) {
+      res.append(policyName, query[policyName]);
+    }
+  }
   next();
 });
 

--- a/server.mjs
+++ b/server.mjs
@@ -52,7 +52,6 @@ app.use(function commonHeaders(req, res, next) {
 
 app.get('/test', (req, res, next) => {
   const on = 'on' in req.query;
-  // res.append('Feature-Policy', `geolocation 'self' https://example.com`);
   if (on) {
     res.append('Feature-Policy', `max-downscaling-image 'none'`);
     res.append('Feature-Policy', `image-compression 'none'`);
@@ -72,29 +71,8 @@ app.get('/test', (req, res, next) => {
 });
 
 app.get('/:demoPage', (req, res, next) => {
-  // const demoPage = req.params.demoPage;
-  // console.log(demoPage)
   res.send(fs.readFileSync('./public/index.html', {encoding: 'utf-8'}));
 });
-
-// // Enable/disable policies on demo pages.
-// app.use('/demos', (req, res, next) => {
-//   const unsizedMedia = 'on' in req.query;
-//   // res.append('Feature-Policy', "camera 'none'; microphone 'none'");
-//   // res.append('Feature-Policy', "autoplay 'self' https://clips.vorwaerts-gmbh.de");
-//   // res.append('Feature-Policy', "fullscreen 'none'");
-//   // res.append('Feature-Policy', "geolocation 'self' https://example.com");
-//   // res.append('Feature-Policy', "midi 'none'");
-//   // res.append('Feature-Policy', "sync-xhr 'none'");
-//   // res.append('Feature-Policy', "vr 'none'");
-//   // res.append('Feature-Policy', "usb 'none'");
-//   // res.append('Feature-Policy', "payment 'none'");
-//   // res.append('Feature-Policy', "vibrate 'none'");
-//   if (unsizedMedia) {
-//     // res.set('Feature-Policy', `unsized-media 'none'`);
-//   }
-//   next();
-// });
 
 app.use(express.static('public', {extensions: ['html', 'htm']}));
 app.use(express.static('node_modules'));


### PR DESCRIPTION
## Echo request query as policy headers
Previously the site uses `iframe.allow` to change feature policy value for demo purposes. However, document policy cannot be set with iframe attribute. The only option is 'Document-Policy' HTTP header.

This PR abandons the allow attribute approach, and uses HTTP header to set policy for both feature policy and document policy.

## Add policy value selector for non-boolean policy values
Previously, we can only select ON or OFF as policy value state from top right links, which is not particular suitable for policies with non-boolean values, such as image policies.

This PR provides the flexiblity to add custom policy value selection.

## Refresh image policy demos
As image policies are migrated to document policy, old demos are broken. This PR refreshes the corresponding headers
so that the demos are back to a functional state.
