### PR TITLE
Fix geolocation demo

### DIFF
--- a/public/demos/geolocation.html
+++ b/public/demos/geolocation.html
@@ -28,33 +28,38 @@
     <span id="allowfeature">...</span>
   </h2>
 
-  <p>This page embeds a Google Map demo from <a
-      href="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation"
-      target="_blank">https://google-developers.appspot.com/</a> (e.g. cross-domain) using the following:</p>
+  <p>
+    The demo attempts to use the
+    <a href="https://www.w3.org/TR/geolocation-API/" target="_blank">Geolocation API</a>
+    to display the user's current location.
+  </p>
 
-  <pre class="snippet">&lt;iframe src="https://google-developers.appspot.com/..."
-        allow="geolocation https://google-developers.appspot.com">&lt;/iframe></pre>
+  <pre class="snippet">
+  navigator.geolocation.getCurrentPosition(
+    p => {
+      displayText(`Successfully retrieved geolocation(${p.coords.latitude}, ${p.coords.longitude})`);
+    },
+    err => {
+      displayText(`Failed to retrieve geolocation: ${err.message}`);
+    });</pre>
 
-  <p>The iframe's demo attempts to use the <a href="https://developers.google.com/maps/documentation/geolocation/intro"
-      target="_blank">Geolocation API</a> to
-    display the user's current location. However, when the parent page uses a more restrictive feature policy
-    (<code>Feature-Policy: geolocation 'self'</code>), the iframe is blocked
-    from accessing geolocation.</p>
-
-  <div class="layout center">
-    <iframe src="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation"
-      allow="geolocation https://google-developers.appspot.com"></iframe>
-  </div>
+  <div class="layout center" id="demo"></div>
 
   <script type="module">
     import {initPage} from '/js/shared.js';
-initPage();
+    initPage();
 
-// navigator.geolocation.getCurrentPosition(position => {
-//   console.log(position.coords.latitude, position.coords.longitude);
-// }, err => {
-//   console.error(err.message);
-// });
+    function displayText(text) {
+      document.querySelector('#demo').textContent = text;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      p => {
+        displayText(`Successfully retrieved geolocation(${p.coords.latitude}, ${p.coords.longitude})`);
+      },
+      err => {
+        displayText(`Failed to retrieve geolocation: ${err.message}`);
+      });
 
 </script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120357238-1"></script>

--- a/public/demos/geolocation.html
+++ b/public/demos/geolocation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,32 +17,37 @@
     }
   </style>
 </head>
+
 <body class="body-padding">
 
-<details class="details">
-  <!-- filled dynamically -->
-</details>
+  <details class="details">
+    <!-- filled dynamically -->
+  </details>
 
-<h2 id="feature-allowed-banner">
-  <span id="allowfeature">...</span>
-</h2>
+  <h2 id="feature-allowed-banner">
+    <span id="allowfeature">...</span>
+  </h2>
 
-<p>This page embeds a Google Map demo from <a href="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation" target="_blank">https://google-developers.appspot.com/</a> (e.g. cross-domain) using the following:</p>
+  <p>This page embeds a Google Map demo from <a
+      href="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation"
+      target="_blank">https://google-developers.appspot.com/</a> (e.g. cross-domain) using the following:</p>
 
-<pre class="snippet">&lt;iframe src="https://google-developers.appspot.com/..."
+  <pre class="snippet">&lt;iframe src="https://google-developers.appspot.com/..."
         allow="geolocation https://google-developers.appspot.com">&lt;/iframe></pre>
 
-<p>The iframe's demo attempts to use the <a href="https://developers.google.com/maps/documentation/geolocation/intro" target="_blank">Geolocation API</a> to
-  display the user's current location. However, when the parent page uses a more restrictive feature policy (<code>Feature-Policy: geolocation 'self'</code>), the iframe is blocked
-  from accessing geolocation.</p>
+  <p>The iframe's demo attempts to use the <a href="https://developers.google.com/maps/documentation/geolocation/intro"
+      target="_blank">Geolocation API</a> to
+    display the user's current location. However, when the parent page uses a more restrictive feature policy
+    (<code>Feature-Policy: geolocation 'self'</code>), the iframe is blocked
+    from accessing geolocation.</p>
 
-<div class="layout center">
-  <iframe src="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation"
-          allow="geolocation https://google-developers.appspot.com"></iframe>
-</div>
+  <div class="layout center">
+    <iframe src="https://google-developers.appspot.com/maps/documentation/javascript/examples/full/map-geolocation"
+      allow="geolocation https://google-developers.appspot.com"></iframe>
+  </div>
 
-<script type="module">
-import {initPage} from '/js/shared.js';
+  <script type="module">
+    import {initPage} from '/js/shared.js';
 initPage();
 
 // navigator.geolocation.getCurrentPosition(position => {
@@ -51,12 +57,16 @@ initPage();
 // });
 
 </script>
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120357238-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-120357238-1');
-</script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120357238-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'UA-120357238-1');
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
Previously we were referencing a external geolocation demo, but it 404s now. 

Replace the demo with a plain javascript one, so that it does not depend on external resource.