### PR TITLE
Update demos to use Permissions-Policy header syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Permissions Policy Demos
+## Permissions Policy and Document Policy Demos
 
-Kitchen sink of [permissions policy](https://www.chromestatus.com/feature/5745992911552512) demos.
+Kitchen sink of [Permissions Policy](https://www.chromestatus.com/feature/5745992911552512) and [Document Policy](https://www.chromestatus.com/feature/5756689661820928) demos.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Feature Policy Demos
+## Permissions Policy Demos
 
-Kitchen sink of [feature policy](https://www.chromestatus.com/feature/5694225681219584) demos.
+Kitchen sink of [permissions policy](https://www.chromestatus.com/feature/5745992911552512) demos.
 
 ### Development
 

--- a/permissions-policy-header.mjs
+++ b/permissions-policy-header.mjs
@@ -111,7 +111,7 @@ export class PermissionsPolicyHeader {
         case "":
           return "'none'";
         default:
-          // Remove leading and tailing '"' in permissions header syntax.
+          // Remove leading and trailing '"' in permissions header syntax.
           return item.slice(1, -1);
       }
     }

--- a/permissions-policy-header.mjs
+++ b/permissions-policy-header.mjs
@@ -1,0 +1,124 @@
+'use strict';
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ export class FeaturePolicyHeader {
+  /**
+   * @param {Map<string, string[]>} policies
+   */
+  constructor(policies) {
+    this.policies = policies;
+  }
+
+  /**
+   * Parse Feature-Policy header string
+   *
+   * @param {string} header_string e.g. unsized-images 'none'; geolocation *; usb foo.com bar.com
+   * @returns {FeaturePolicyHeader}
+   */
+  static parse(header_string) {
+    if (!header_string)
+      return new FeaturePolicyHeader(new Map());
+
+    return new FeaturePolicyHeader(header_string.split(';')
+      .reduce((acc, item) => {
+        const [policyName, ...allowlist] = item.trim().split(' ').filter(s => s !== '');
+        acc.set(policyName, allowlist);
+        return acc;
+      }, new Map()));
+  }
+
+  serialize() {
+    return [...this.policies.entries()]
+      .map(([policyName, allowlist]) => `${policyName} ${allowlist.join(' ')}`)
+      .join('; ');
+  }
+};
+
+export class PermissionsPolicyHeader {
+  /**
+   * @param {Map<string, string[]>} policies
+   */
+  constructor(policies) {
+    this.policies = policies;
+  }
+  /**
+   * Parse Permissions-Policy header string.
+   *
+   * Note: Permissions-Policy header uses Dictionary in [structured header syntax]
+   *(https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html).
+   *
+   * Note: This function does not provide full structured header syntax parsing.
+   * When incomplete syntax is received, it can lead to unexpected behaviour.
+   *
+   * @param {string} header_string e.g. p1=(), p2=("foo.com" "bar.com"), p3=self
+   * @returns {PermissionsPolicyHeader}
+   */
+  static parse(header_string) {
+    if (!header_string)
+      return new PermissionsPolicyHeader(new Map());
+
+    return new PermissionsPolicyHeader(header_string.split(',')
+      .reduce((acc, item) => {
+        const [policyName, allowlist_string] = item.split('=').map(s => s.trim());
+
+        const match_result = allowlist_string.match(/\((.*)\)/);
+        // Bracket is optional when there is only single item in SH's dictionary
+        // value.
+        const allowlist = match_result ? (
+          match_result.length > 1 ? match_result[1].split(' ') : ['']
+        ) : [allowlist_string];
+        acc.set(policyName, allowlist);
+        return acc;
+      }, new Map()));
+  }
+
+  serialize() {
+    return [...this.policies.entries()]
+      .map(([policyName, allowlist]) => `${policyName}=(${allowlist.join(' ')})`)
+      .join(', ');
+  }
+
+  /**
+   * @returns {FeaturePolicyHeader}
+   */
+  toFeaturePolicy() {
+    /**
+     * Convert permissions policy allowlist item to feature policy allowlist
+     * item.
+     * @param {string} item
+     * @returns {string}
+     */
+    function mapAllowlistItem(item) {
+      switch (item) {
+        case '*':
+          return '*';
+        case "self":
+          return "'self'";
+        case "":
+          return "'none'";
+        default:
+          // Remove leading and tailing '"' in permissions header syntax.
+          return item.slice(1, -1);
+      }
+    }
+    return new FeaturePolicyHeader(
+      new Map(
+        [...this.policies.entries()]
+        .map(([feature, allowlist]) => [feature, allowlist.map(mapAllowlistItem)])
+      ));
+  }
+};

--- a/public/demos/animations.html
+++ b/public/demos/animations.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Permissions Policy: animations example</title>
+  <title>Document Policy: animations example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/animations.html
+++ b/public/demos/animations.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: animations example</title>
+  <title>Permissions Policy: animations example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/autoplay.html
+++ b/public/demos/autoplay.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: autoplay example</title>
+  <title>Permissions Policy: autoplay example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">
@@ -19,7 +19,7 @@
   <span id="allowfeature">...</span>
 </h2>
 
-<p>The video below uses <code>autoplay</code> attribute. Reload the page with the feature policy on/off to see the effect on it auto playing.</p>
+<p>The video below uses <code>autoplay</code> attribute. Reload the page with the permissions policy on/off to see the effect on it auto playing.</p>
 
 <div class="layout center">
   <video src="/video/mixkit-rain-falling-from-the-roof-on-a-rainy-day-2716.mp4" autoplay controls></video>

--- a/public/demos/autoplay.html
+++ b/public/demos/autoplay.html
@@ -19,7 +19,7 @@
   <span id="allowfeature">...</span>
 </h2>
 
-<p>The video below uses <code>autoplay</code> attribute. Reload the page with the permissions policy on/off to see the effect on it auto playing.</p>
+<p>The video below uses <code>autoplay</code> attribute. Reload the page with the policy on/off to see the effect on it auto playing.</p>
 
 <div class="layout center">
   <video src="/video/mixkit-rain-falling-from-the-roof-on-a-rainy-day-2716.mp4" autoplay controls></video>

--- a/public/demos/geolocation.html
+++ b/public/demos/geolocation.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: geolocation example</title>
+  <title>Permissions Policy: geolocation example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/demos/picture-in-picture.html
+++ b/public/demos/picture-in-picture.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: Picture-in-Picture example</title>
+  <title>Permissions Policy: Picture-in-Picture example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">
@@ -19,7 +19,7 @@
   <span id="allowfeature">...</span>
 </h2>
 
-<p>The video below uses native controls. Reload the page with the feature policy
+<p>The video below uses native controls. Reload the page with the permissions policy
   on/off to see the effect on its controls.</p>
 
 <p><b>Note</b>: At the moment, you may need to enable the

--- a/public/demos/vertical-scroll.html
+++ b/public/demos/vertical-scroll.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy: vertical-scroll example</title>
+  <title>Permissions Policy: vertical-scroll example</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Feature Policy Kitchen Sink</title>
+  <title>Permissions Policy Kitchen Sink</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/header.css">
@@ -34,7 +34,7 @@
       <img src="/img/sink.svg" title="It's a kitchen sink!" alt="It's a kitchen sink!">
     </div>
     <a href="/" target="_self">
-      <h2 class="drawer-title">Feature Policy</h2>
+      <h2 class="drawer-title">Permissions Policy</h2>
       <h3 class="drawer-subtitle">Demos</h3>
     </a>
   </header>
@@ -59,17 +59,18 @@
 
   <div>
     <div id="intro-summary" class="body-padding">
-      <h2><a href="https://developers.google.com/web/updates/2018/06/feature-policy" target="_blank">Feature Policy</a>
+      <!-- TODO: update documentation link. -->
+      <h2><a href="https://developers.google.com/web/updates/2018/06/feature-policy" target="_blank">Permissions Policy</a>
         allows web developers to selectively enable, disable, and modify the behavior
         of various features and APIs in the browser. This can provide a well-lit path towards good performance
         and prevent common footguns when building and maintaining web apps.</h2>
-      <h3 class="notsupported">Feature policy is not supported in your browser. Try Chrome Canary and enable the <code>--enable-experimental-web-platform-features</code> flag.</h3>
-      <h3 style="margin-top:var(--default-padding-3x);">You control feature policies through an HTTP header:</h3>
+      <h3 class="notsupported">Permissions policy is not supported in your browser. Try Chrome Canary and enable the <code>--enable-experimental-web-platform-features</code> flag.</h3>
+      <h3 style="margin-top:var(--default-padding-3x);">You control permissions policies through an HTTP header:</h3>
       <p>
-        <pre class="snippet">Feature-Policy: geolocation *
-Feature-Policy: geolocation 'none'
-Feature-Policy: geolocation 'self'
-Feature-Policy: geolocation https://google-developers.appspot.com</pre>
+        <pre class="snippet">Permissions-Policy: geolocation=*
+Permissions-Policy: geolocation=()
+Permissions-Policy: geolocation=self
+Permissions-Policy: geolocation="https://google-developers.appspot.com"</pre>
       </p>
       <h3 style="margin-top:var(--default-padding-3x);">or by adding the <code>allow</code> attribute on iframes:</h3>
       <p>

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
       <img src="/img/sink.svg" title="It's a kitchen sink!" alt="It's a kitchen sink!">
     </div>
     <a href="/" target="_self">
-      <h2 class="drawer-title">Permissions Policy</h2>
+      <h2 class="drawer-title">Permissions/<br>Document Policy</h2>
       <h3 class="drawer-subtitle">Demos</h3>
     </a>
   </header>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,7 +19,7 @@
 import {html, render} from '/lit-html/lit-html.js';
 import {repeat} from '/lit-html/directives/repeat.js';
 import {until} from '/lit-html/directives/until.js';
-import {fetchPolicies, updateDetailsHeader, getPolicy, featurePolicyAPISupported} from '/js/shared.js';
+import {fetchPolicies, updateDetailsHeader, getPolicy, permissionsPolicyAPISupported} from '/js/shared.js';
 
 const POLICY_TYPE_TO_LABEL = {
   performance: 'Performance',
@@ -102,8 +102,9 @@ function toggleDrawer(forClose = false) {
  * @param {Array<Object>} implementedPolicies
  */
 async function leftOverPolicies(implementedPolicies) {
-  const featurePolicy = document.policy || document.featurePolicy;
-  const allPolicies = featurePolicy.allowedFeatures().sort();
+  const permissionsPolicy =
+    document.policy || document.permissionsPolicy || document.featurePolicy;
+  const allPolicies = permissionsPolicy.allowedFeatures().sort();
 
   const policies = [];
   allPolicies.forEach((item, i) => {
@@ -120,7 +121,7 @@ async function leftOverPolicies(implementedPolicies) {
 
 
 (async () => {
-if (!featurePolicyAPISupported) {
+if (!permissionsPolicyAPISupported) {
   document.querySelector('.notsupported').classList.add('show');
   return;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ const POLICY_TYPE_TO_LABEL = {
 
 /**
  * Dynamically loads policy demo page based off current (deep link) url.
- * @return {!Object} Permissions policy info.
+ * @return {!Object} Policy info.
  */
 async function loadPage() {
   let policy = null;
@@ -103,7 +103,7 @@ function toggleDrawer(forClose = false) {
  */
 async function leftOverPolicies(implementedPolicies) {
   const permissionsPolicy =
-    document.policy || document.permissionsPolicy || document.featurePolicy;
+    document.permissionsPolicy || document.featurePolicy;
   const allPolicies = permissionsPolicy.allowedFeatures().sort();
 
   const policies = [];

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -73,7 +73,7 @@ function updatePolicyValue(anchor) {
 /**
  * Updates the dynamic portions of the page.
  * @param {!HTMLAnchorElement} anchor
- * @param {string} id Permissions policy id.
+ * @param {string} id Policy id.
  */
 async function updatePage(anchor, id) {
   // Update window URL first, so that |updateDetailsHeader| can observe

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ const POLICY_TYPE_TO_LABEL = {
 
 /**
  * Dynamically loads policy demo page based off current (deep link) url.
- * @return {!Object} Feature policy info.
+ * @return {!Object} Permissions policy info.
  */
 async function loadPage() {
   let policy = null;
@@ -73,7 +73,7 @@ function updatePolicyValue(anchor) {
 /**
  * Updates the dynamic portions of the page.
  * @param {!HTMLAnchorElement} anchor
- * @param {string} id Feature policy id.
+ * @param {string} id Permissions policy id.
  */
 async function updatePage(anchor, id) {
   // Update window URL first, so that |updateDetailsHeader| can observe

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -41,7 +41,7 @@
   "url": "/demos/autoplay.html",
   "chromeStatusLink": "https://www.chromestatus.com/feature/5100524789563392",
   "what": "Allows cross-origin videos and movies to autoplay.",
-  "why": "By default, Chrome allows the `autoplay` attribute on videos within same-origin iframes. To enable cross-origin videos to autoplay (or disallow same-origin videos from auto playing), sites can use this feature policy.",
+  "why": "By default, Chrome allows the `autoplay` attribute on videos within same-origin iframes. To enable cross-origin videos to autoplay (or disallow same-origin videos from auto playing), sites can use this permissions policy.",
   "policyType": "Permissions-Policy",
   "usage": {
     "off": "autoplay=self",
@@ -60,7 +60,7 @@
   "url": "/demos/geolocation.html",
   "chromeStatusLink": null,
   "what": "Allows/disables the use of the Geolocation API.",
-  "why": "By default, Chrome blocks the usage of geolocation in cross-origin iframes. Developers can control this behavior (or geolocation access in general) using this feature policy.",
+  "why": "By default, Chrome blocks the usage of geolocation in cross-origin iframes. Developers can control this behavior (or geolocation access in general) using this permissions policy.",
   "policyType": "Permissions-Policy",
   "usage": {
     "off": "geolocation=self",
@@ -82,7 +82,7 @@
   "url": "/demos/picture-in-picture.html",
   "chromeStatusLink": "https://www.chromestatus.com/features/5729206566649856",
   "what": "Controls access to Picture in Picture.",
-  "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
+  "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this permissions policy.",
   "policyType": "Permissions-Policy",
   "usage": {
     "on": "picture-in-picture=self",

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -24,14 +24,14 @@
   "chromeStatusLink": "https://www.chromestatus.com/feature/5154875084111872",
   "what": "Disallows the use of synchronous XMLHttpRequests.",
   "why": "Using synchronous XHRs can cause jank on the main thread and be detrimental to user experience. Although the HTML spec has <a href=\"https://xhr.spec.whatwg.org/#sync-warning\" target=\"_blank\">deprecated sync XHRs</a>, developers are still able to use it for XHR requests where <code>responseType=\"text\"</code>.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "off": "sync-xhr 'self'",
-    "on": "sync-xhr 'none'"
+    "off": "sync-xhr=self",
+    "on": "sync-xhr=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: sync-xhr 'none'"
+      "Permissions-Policy: sync-xhr=()"
     ]
   }
 }, {
@@ -42,15 +42,15 @@
   "chromeStatusLink": "https://www.chromestatus.com/feature/5100524789563392",
   "what": "Allows cross-origin videos and movies to autoplay.",
   "why": "By default, Chrome allows the `autoplay` attribute on videos within same-origin iframes. To enable cross-origin videos to autoplay (or disallow same-origin videos from auto playing), sites can use this feature policy.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "off": "autoplay 'self'",
-    "on": "autoplay 'none'"
+    "off": "autoplay=self",
+    "on": "autoplay=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: autoplay 'none'",
-      "Feature-Policy: autoplay 'self'"
+      "Permissions-Policy: autoplay=()",
+      "Permissions-Policy: autoplay=self"
     ]
   }
 }, {
@@ -61,15 +61,15 @@
   "chromeStatusLink": null,
   "what": "Allows/disables the use of the Geolocation API.",
   "why": "By default, Chrome blocks the usage of geolocation in cross-origin iframes. Developers can control this behavior (or geolocation access in general) using this feature policy.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "off": "geolocation 'self'",
-    "on": "geolocation https://google-developers.appspot.com"
+    "off": "geolocation=self",
+    "on": "geolocation=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: geolocation 'self'",
-      "Feature-Policy: geolocation https://google-developers.appspot.com"
+      "Permissions-Policy: geolocation=self",
+      "Permissions-Policy: geolocation https://google-developers.appspot.com"
     ],
     "iframe": [
       "&lt;iframe src=\"...\" allow=\"geolocation https://google-developers.appspot.com\"><\/iframe>"
@@ -83,15 +83,15 @@
   "chromeStatusLink": "https://www.chromestatus.com/features/5729206566649856",
   "what": "Controls access to Picture in Picture.",
   "why": "By default, Chrome allows the usage of Picture-in-Picture in cross-origin iframes. Developers can disable it using this feature policy.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "on": "picture-in-picture 'self'",
-    "off": "picture-in-picture 'none'"
+    "on": "picture-in-picture=self",
+    "off": "picture-in-picture=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: picture-in-picture 'self'",
-      "Feature-Policy: picture-in-picture 'none'"
+      "Permissions-Policy: picture-in-picture=self",
+      "Permissions-Policy: picture-in-picture=()"
     ]
   }
 }, {
@@ -101,14 +101,14 @@
   "url": "/demos/animations.html",
   "what": "Restricts the set of CSS properties which can be animated to opacity, transform, and filter.",
   "why": "Ensures smooth animations, by only allowing those properties which can be animated on the GPU using the hardware acceleration.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "off": "animations 'self'",
-    "on": "animations 'none'"
+    "off": "animations=self",
+    "on": "animations=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: animations 'none'"
+      "Permissions-Policy: animations=()"
     ],
     "iframe": [
       "&lt;iframe allow=\"animations https:\/\/anim8.cdn.com\" src=\"...\"><\/iframe>"
@@ -178,14 +178,14 @@
   "url": "/demos/vertical-scroll.html",
   "what": "Controls whether embedded content can interfere with vertical scrolling.",
   "why": "By default, iframe content can use <code>touch-action: none</code>, <code>e.preventDefault()</code> in touch events, and the DOM Scroll APIs to prevent and/or alter how content scrolls vertically. This policy ensures vertical scrolling is not blocked by preventing these features from working.",
-  "policyType": "Feature-Policy",
+  "policyType": "Permissions-Policy",
   "usage": {
-    "off": "vertical-scroll 'self'",
-    "on": "vertical-scroll 'none'"
+    "off": "vertical-scroll=self",
+    "on": "vertical-scroll=()"
   },
   "examples": {
     "header": [
-      "Feature-Policy: vertical-scroll 'none'"
+      "Permissions-Policy: vertical-scroll=()"
     ],
     "iframe": [
       "&lt;iframe allow=\"vertical-scroll 'none'\" src=\"...\"><\/iframe>"

--- a/public/js/policies.json
+++ b/public/js/policies.json
@@ -101,17 +101,14 @@
   "url": "/demos/animations.html",
   "what": "Restricts the set of CSS properties which can be animated to opacity, transform, and filter.",
   "why": "Ensures smooth animations, by only allowing those properties which can be animated on the GPU using the hardware acceleration.",
-  "policyType": "Permissions-Policy",
+  "policyType": "Document-Policy",
   "usage": {
-    "off": "animations=self",
-    "on": "animations=()"
+    "off": "animations",
+    "on": "animations=?0"
   },
   "examples": {
     "header": [
-      "Permissions-Policy: animations=()"
-    ],
-    "iframe": [
-      "&lt;iframe allow=\"animations https:\/\/anim8.cdn.com\" src=\"...\"><\/iframe>"
+      "Document-Policy: animations=?0"
     ]
   }
 }, {

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -125,7 +125,7 @@ function policyValueSelector(policy) {
 }
 
 /**
- * Updates the UI metadata header when a permissions policy is selected.
+ * Updates the UI metadata header when a policy is selected.
  * @param {!Object} policy
  */
 function updateDetailsHeader(policy) {

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -127,7 +127,7 @@ function policyValueSelector(policy) {
 }
 
 /**
- * Updates the UI metadata header when a feature policy is selected.
+ * Updates the UI metadata header when a permissions policy is selected.
  * @param {!Object} policy
  */
 function updateDetailsHeader(policy) {

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -21,9 +21,16 @@ import {ifDefined} from '/lit-html/directives/if-defined.js';
 export const policyOn = new URL(location).searchParams.has('on');
 export const currentPolicyId = new URL(location).pathname.split('/').slice(-1)[0].split('.')[0];
 
-export const featurePolicyAPISupported = 'policy' in document || 'featurePolicy' in document;
+export const permissionsPolicyAPISupported =
+  'policy' in document ||
+  'featurePolicy' in document ||
+  'permissionsPolicy' in document;
 
-const featurePolicy = document.policy || document.featurePolicy;
+const permissionsPolicy =
+  document.policy ||
+  document.featurePolicy ||
+  document.permissionsPolicy;
+
 let policies = [];
 let fetchingPoliciesPromise = null;
 
@@ -75,10 +82,10 @@ async function getPolicy(id) {
  * @return {!Boolean}
  */
 function policySupported(id) {
-  if (!featurePolicyAPISupported) {
+  if (!permissionsPolicyAPISupported) {
     return false;
   }
-  return featurePolicy.allowedFeatures().findIndex(el => el === id) !== -1;
+  return permissionsPolicy.allowedFeatures().findIndex(el => el === id) !== -1;
 }
 
 /**
@@ -157,7 +164,7 @@ function updateDetailsHeader(policy) {
  * @return {boolean} True if the current policy is enabled.
  */
 function updateAllowBanner(policyId) {
-  const allowsFeature = featurePolicy.allowsFeature(policyId);
+  const allowsFeature = permissionsPolicy.allowsFeature(policyId);
   const allows = allowsFeature ? 'enables' : 'disables';
   const banner = document.querySelector('#feature-allowed-banner');
   if (!banner) {

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -22,12 +22,10 @@ export const policyOn = new URL(location).searchParams.has('on');
 export const currentPolicyId = new URL(location).pathname.split('/').slice(-1)[0].split('.')[0];
 
 export const permissionsPolicyAPISupported =
-  'policy' in document ||
   'featurePolicy' in document ||
   'permissionsPolicy' in document;
 
 const permissionsPolicy =
-  document.policy ||
   document.featurePolicy ||
   document.permissionsPolicy;
 

--- a/server.mjs
+++ b/server.mjs
@@ -20,7 +20,7 @@ import fs from 'fs';
 import express from 'express';
 import bodyParser from 'body-parser';
 
-import {FeaturePolicyHeader, PermissionsPolicyHeader} from './permissions-policy-header.mjs';
+import {PermissionsPolicyHeader} from './permissions-policy-header.mjs';
 
 const OT_TOKEN_UNOPT_IMAGES = 'AiGYzl8A17mcET9ObZ6QbC5vmOlCWk+4jZwZptDwKw8Iguu3jX2e6WVzUbHZpW0zPgqZdq/WSSUysH2chjMtCA4AAAByeyJvcmlnaW4iOiJodHRwczovL2ZlYXR1cmUtcG9saWN5LWRlbW9zLmFwcHNwb3QuY29tOjQ0MyIsImZlYXR1cmUiOiJVbm9wdGltaXplZEltYWdlUG9saWNpZXMiLCJleHBpcnkiOjE1NjQ2Nzg1NjF9';
 const OT_TOKEN_UNOPT_IMAGES_LOCALHOST = 'AuqelXxw7r91rz8mkV5fJnMkjNXY6vtmpd8lzATN2KGpwd0D6akFg7GBtigifHHuqk7zAnOvo2NlUnmAQTmSTQkAAABbeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiVW5vcHRpbWl6ZWRJbWFnZVBvbGljaWVzIiwiZXhwaXJ5IjoxNTY0Njc4MzU1fQ==';

--- a/server.mjs
+++ b/server.mjs
@@ -20,6 +20,8 @@ import fs from 'fs';
 import express from 'express';
 import bodyParser from 'body-parser';
 
+import {FeaturePolicyHeader, PermissionsPolicyHeader} from './permissions-policy-header.mjs';
+
 const OT_TOKEN_UNOPT_IMAGES = 'AiGYzl8A17mcET9ObZ6QbC5vmOlCWk+4jZwZptDwKw8Iguu3jX2e6WVzUbHZpW0zPgqZdq/WSSUysH2chjMtCA4AAAByeyJvcmlnaW4iOiJodHRwczovL2ZlYXR1cmUtcG9saWN5LWRlbW9zLmFwcHNwb3QuY29tOjQ0MyIsImZlYXR1cmUiOiJVbm9wdGltaXplZEltYWdlUG9saWNpZXMiLCJleHBpcnkiOjE1NjQ2Nzg1NjF9';
 const OT_TOKEN_UNOPT_IMAGES_LOCALHOST = 'AuqelXxw7r91rz8mkV5fJnMkjNXY6vtmpd8lzATN2KGpwd0D6akFg7GBtigifHHuqk7zAnOvo2NlUnmAQTmSTQkAAABbeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiVW5vcHRpbWl6ZWRJbWFnZVBvbGljaWVzIiwiZXhwaXJ5IjoxNTY0Njc4MzU1fQ==';
 
@@ -68,7 +70,17 @@ app.use('/demos/:demoPage', function attachHeader(req, res, next) {
     const usageKey = requestParamNames[0];
 
     if (usageKey in targetPolicy.usage) {
-      res.append(targetPolicy.policyType, targetPolicy.usage[usageKey]);
+      const policyType = targetPolicy.policyType;
+      const policyValue = targetPolicy.usage[usageKey];
+
+      res.append(policyType, policyValue);
+
+      // Attach 'Feature-Policy' header as well for backward compatibility.
+      if (policyType === 'Permissions-Policy') {
+        const featurePolicyValue =
+          PermissionsPolicyHeader.parse(policyValue).toFeaturePolicy().serialize();
+        res.append('Feature-Policy', featurePolicyValue);
+      }
     }
   }
 


### PR DESCRIPTION
This PR renames all remaining 'feature policy' occurence with 'permissions policy' in 
- code comments
- function names, variable names
- html content
- README

Header syntax in policies.json has been updated.

Both the 'Permissions-Policy' HTTP header and 'Feature-Policy' HTTP header will be send for backward compatibility.
(See modification in server.mjs)