### PR TITLE
Update document policy feature demo page banner

### DIFF
--- a/public/demos/oversized-images.html
+++ b/public/demos/oversized-images.html
@@ -15,10 +15,6 @@
   <!-- filled dynamically -->
 </details>
 
-<h2 id="feature-allowed-banner">
-  <span id="allowfeature">...</span>
-</h2>
-
 <p>Click the buttons above to see how the page loads with different policy values.
  Images where the ratio of intrinsic dimensions to container size exceeds the given
  threshold should render as placeholder images.</p>

--- a/public/demos/unoptimized-lossy-images.html
+++ b/public/demos/unoptimized-lossy-images.html
@@ -15,10 +15,6 @@
   <!-- filled dynamically -->
 </details>
 
-<h2 id="feature-allowed-banner">
-  <span id="allowfeature">...</span>
-</h2>
-
 <p>Click the buttons above to see how the page loads with different policy values.
  Images where the compression ratio (bytes per pixel) exceeds the threshold should render as placeholder images.
 </p>

--- a/public/demos/unsized-media.html
+++ b/public/demos/unsized-media.html
@@ -16,9 +16,6 @@
   <!-- filled dynamically -->
 </details>
 
-<h2 id="feature-allowed-banner">
-  <span id="allowfeature">...</span>
-</h2>
 
 <p>Click the disallow/allow buttons above to see how the page loads with the policy on and off.
   When the policy is on, you won't see layout thrashing as large images load. Media without

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -126,7 +126,7 @@ function policyValueSelector(policy) {
  */
 function notSupportedBanner(policy) {
   if ('Document-Policy'.localeCompare(policy.policyType) === 0) {
-    return `
+    return html `
     <div class="notsupported show" style="background: orange">
       <span>This policy is experimental<br>
       <img src="/img/flag-24px.svg" class="flag-icon">
@@ -134,7 +134,7 @@ function notSupportedBanner(policy) {
       <code>--enable-experimental-web-platform-features</code> flag.</span>
     </div>`;
   } else {
-    return `
+    return html `
     <div class="notsupported ${policy.supported ? '' : 'show'}">
       <span>This policy is not supported in your browser.<br>
       <img src="/img/flag-24px.svg" class="flag-icon">Try running Chrome Canary with the
@@ -166,7 +166,7 @@ function updateDetailsHeader(policy) {
       <li><label>Why</label><span>${unsafeHTML(policy.why)}</span></li>
       <li><label>Examples</label><div>${unsafeHTML(examples)}</div></li>
     </ul>
-    ${unsafeHTML(notSupportedBanner(policy))}`;
+    ${notSupportedBanner(policy)}`;
 
   render(tmpl, document.querySelector('.details'));
 }
@@ -181,8 +181,6 @@ function updateAllowBanner(policyId) {
   const allows = allowsFeature ? 'enables' : 'disables';
   const banner = document.querySelector('#feature-allowed-banner');
   if (!banner) {
-    /* eslint-disable-next-line */
-    console.warn('No #feature-allowed-banner element found.');
     return;
   }
   banner.classList.toggle('allows', allowsFeature);

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -120,6 +120,30 @@ function policyValueSelector(policy) {
 }
 
 /**
+ * Render the not supported banner html string based on policy object given.
+ * @param {!Object} policy
+ * @return {string}
+ */
+function notSupportedBanner(policy) {
+  if ('Document-Policy'.localeCompare(policy.policyType) === 0) {
+    return `
+    <div class="notsupported show" style="background: orange">
+      <span>This policy is experimental<br>
+      <img src="/img/flag-24px.svg" class="flag-icon">
+      Please make sure you are running Chrome Canary with the
+      <code>--enable-experimental-web-platform-features</code> flag.</span>
+    </div>`;
+  } else {
+    return `
+    <div class="notsupported ${policy.supported ? '' : 'show'}">
+      <span>This policy is not supported in your browser.<br>
+      <img src="/img/flag-24px.svg" class="flag-icon">Try running Chrome Canary with the
+      <code>--enable-experimental-web-platform-features</code> flag.</span>
+    </div>`;
+  }
+}
+
+/**
  * Updates the UI metadata header when a feature policy is selected.
  * @param {!Object} policy
  */
@@ -142,11 +166,7 @@ function updateDetailsHeader(policy) {
       <li><label>Why</label><span>${unsafeHTML(policy.why)}</span></li>
       <li><label>Examples</label><div>${unsafeHTML(examples)}</div></li>
     </ul>
-    <div class="notsupported ${policy.supported ? '' : 'show'}">
-      <span>This policy is not supported in your browser.<br>
-      <img src="/img/flag-24px.svg" class="flag-icon">Try running Chrome Canary with the
-      <code>--enable-experimental-web-platform-features</code> flag.</span>
-    </div>`;
+    ${unsafeHTML(notSupportedBanner(policy))}`;
 
   render(tmpl, document.querySelector('.details'));
 }

--- a/public/js/shared.js
+++ b/public/js/shared.js
@@ -167,12 +167,7 @@ function updateAllowBanner(policyId) {
   }
   banner.classList.toggle('allows', allowsFeature);
   banner.classList.add('show');
-  /* override banner description for unoptimized-images */
-  if (policyId == 'unoptimized-lossy-images') {
-    document.querySelector('#allowfeature').textContent = `Page ${allows} unoptimized-\{lossy,lossless\}-images.`;
-  } else {
-    document.querySelector('#allowfeature').textContent = `Page ${allows} ${currentPolicyId}.`;
-  }
+  document.querySelector('#allowfeature').textContent = `Page ${allows} ${currentPolicyId}.`;
 
   return allowsFeature;
 }


### PR DESCRIPTION
Currently there is no way to tell wether document policy is supported in the browser, because there is no JS API for document policy. 

- Use a warning banner instead of error banner for document policy demo pages.
- Remove blue `feature-allowed-banner`.

Before: 
![Screen Shot 2020-10-15 at 2 21 55 PM](https://user-images.githubusercontent.com/20929282/96170598-cc27ce00-0ef1-11eb-9268-bfadf6d8e21d.png)

After:
![Screen Shot 2020-10-15 at 2 20 45 PM](https://user-images.githubusercontent.com/20929282/96170623-d1851880-0ef1-11eb-9a3d-56a064e6b7eb.png)
